### PR TITLE
Call configlet subcommand on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ install:
   - source $HOME/.sdkman/bin/sdkman-init.sh
   - sdk install ceylon
 script:
-  - bin/configlet .
+  - bin/configlet lint .
   - bin/compile-all-stubs
   - bin/test-all-exercises


### PR DESCRIPTION
This changes configlet to pass a subcommand.

For now, we've released a version of configlet which handles both the old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we
release the version of configlet that requires the subcommand.


https://github.com/exercism/configlet/pull/23