### PR TITLE
hamming: declare compliance with problem-specifications 2.0.0

### DIFF
--- a/exercises/hamming/source/hamming/HammingTest.ceylon
+++ b/exercises/hamming/source/hamming/HammingTest.ceylon
@@ -1,6 +1,6 @@
 import ceylon.test { ... }
 
-// Tests adapted from problem-specifications version 1.0.0
+// Tests adapted from problem-specifications version 2.0.0
 {[String, String, Integer?]*} cases => {
   // identical strands
   ["A", "A", 0],


### PR DESCRIPTION
No additional action needs to be taken; we were already expecting an
error for the cases of unequal length (which is what 2.0.0 provides).

https://github.com/exercism/problem-specifications/pull/875