### PR TITLE
rna-transcription: provide more accurate source info

### DIFF
--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -35,7 +35,7 @@ ceylon compile && ceylon test $(basename source/*)
 
 ## Source
 
-Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
Original source seemed to mention a simple replacement of T with U
rather than the transcription being performed.

https://github.com/exercism/problem-specifications/issues/1078
https://github.com/exercism/problem-specifications/pull/1134