### PR TITLE
bracket-push 1.3.0: Add paired inside unpaired

### DIFF
--- a/exercises/bracket-push/source/bracketpush/BracketsTest.ceylon
+++ b/exercises/bracket-push/source/bracketpush/BracketsTest.ceylon
@@ -2,7 +2,7 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 1.2.0
+// Tests adapted from problem-specifications version 1.3.0
 
 {[String, Boolean]*} cases => {
     // paired square brackets
@@ -17,6 +17,8 @@ import ceylon.test {
     ["{]", false],
     // paired with whitespace
     ["{ }", true],
+    // partially paired brackets
+    ["{[])", false],
     // simple nested brackets
     ["{[]}", true],
     // several paired brackets


### PR DESCRIPTION
Guards against solutions immediately declaring the entire string matched
as soon as they find any one matched pair.

https://github.com/exercism/problem-specifications/pull/1219