### PR TITLE
rna-transcription: no-op declare compliance with 1.3.0

### DIFF
--- a/exercises/rna-transcription/source/rnatranscription/RNATest.ceylon
+++ b/exercises/rna-transcription/source/rnatranscription/RNATest.ceylon
@@ -2,7 +2,7 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 1.2.0
+// Tests adapted from problem-specifications version 1.3.0
 // The Ceylon track keeps the Error cases from 1.0.1 (removed in 1.1.0)
 
 {[String, String|Null]*} cases => {


### PR DESCRIPTION
1.3.0 added the empty case, which we already had

https://github.com/exercism/problem-specifications/issues/1264
https://github.com/exercism/problem-specifications/pull/1266

Empty case added to Ceylon track:
https://github.com/exercism/ceylon/pull/47#discussion_r134823457