### PR TITLE
travis: Install java via sdkman

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,16 @@ install:
   - bin/fetch-configlet
   - curl -s https://get.sdkman.io | bash
   - source $HOME/.sdkman/bin/sdkman-init.sh
+  - sdk list java
+    # Ceylon 1.3.3 is not ready for java 10 or 11:
+    #     ceylon compile: invalid source release: 10
+    #     ceylon compile: invalid source release: 11
+    # Ceylon 1.3.3 is not ready for java 9:
+    #     ceylon format: Could not load module 'ceylon.formatter/1.3.3' because: com.
+    #     redhat.ceylon.cmr.ceylon.loader.ModuleNotFoundException: Could not find module:
+    #     javax.xml/7
+    # Try later version of Java when using a later version of Cyelon.
+  - sdk install java 8.0.181-zulu
   - sdk install ceylon
 script:
   - bin/configlet lint .


### PR DESCRIPTION
Otherwise, Travis CI fails with:

    Java not found, you must install Java in order to compile and run Ceylon programs
    Go to http://www.java.com/getjava/ to download the latest version of Java

Unknown what changed.

It is known that sdkman version changed from 5.7.2+323 to 5.7.3+337
however nothing in 5.7.3 seems related, so not likely to be that.

A successful build:
https://travis-ci.org/exercism/ceylon/builds/434241647

A failed build:
https://travis-ci.org/exercism/ceylon/builds/437263366