### PR TITLE
travis: Install any arbitrary 8.0 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     #     redhat.ceylon.cmr.ceylon.loader.ModuleNotFoundException: Could not find module:
     #     javax.xml/7
     # Try later version of Java when using a later version of Cyelon.
-  - sdk install java 8.0.181-zulu
+  - sdk install java $(sdk list java | grep '^ *8\..*zulu' | head -1)
   - sdk install ceylon
 script:
   - bin/configlet lint .


### PR DESCRIPTION
Well, 8.0.181-zulu isn't available anymore, but 8.0.192-zulu is! But it
does not make sense to have to update this file every time that changes.