### PR TITLE
config/maintainers: show a bio for me on the website

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -14,12 +14,12 @@
     {
       "github_username": "petertseng",
       "alumnus": false,
-      "show_on_website": false,
+      "show_on_website": true,
       "name": null,
       "link_text": null,
       "link_url": null,
       "avatar_url": null,
-      "bio": null
+      "bio": "I was introduced to Ceylon by a contributor to the project. I found the union and intersection types interesting and thus I took the track under my wing. I find the track a good way to test Ceylon code and ideas. Getting the track officially launched isn't the highest on my priority list, but I'm happy to advise an interested party in making it happen."
     }
   ]
 }


### PR DESCRIPTION
Otherwise, https://exercism.io/tracks/ceylon/maintainers would be empty,
and may dismay people into thinking there are no maintainers!!!

This makes my status and goal for the track clear.