### PR TITLE
travis: reject invalid UUIDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,16 @@ install:
   - sdk install ceylon
 script:
   - bin/configlet lint .
+  - |
+    # Check for invalid UUIDs.
+    # can be removed once `configlet lint` gains this ability.
+    # Check issue https://github.com/exercism/configlet/issues/99
+    bad_uuid=$(jq --raw-output '.exercises | map(.uuid) | .[]' config.json | grep -vE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+    if [ -n "$bad_uuid" ]; then
+      echo "invalid UUIDs found! please correct these to be valid UUIDs:"
+      echo "$bad_uuid"
+      exit 1
+    fi
   - bin/compile-all-stubs
   - bin/test-all-exercises
   - |

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "exercises": [
     {
       "slug": "leap",
-      "uuid": "9ae32021-a7c3-4ddf-88b1-629b708b9cb90",
+      "uuid": "9ae32021-a7c3-4ddf-88b1-629b708b9cb9",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -15,7 +15,7 @@
     },
     {
       "slug": "hamming",
-      "uuid": "a93dbf6e-c65d-4793-9407-f8187abd0ad",
+      "uuid": "a93dbf6e-c65d-4793-9407-f8187abd0ad7",
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
@@ -26,7 +26,7 @@
     },
     {
       "slug": "sieve",
-      "uuid": "bc986de4-f76f-4435-b7aa-08e561693c4g",
+      "uuid": "bc986de4-f76f-4435-b7aa-08e561693c49",
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "exercises": [
     {
       "slug": "leap",
-      "uuid": "9ae32021-a7c3-4ddf-88b1-629b708b9cb9",
+      "uuid": "9ae32021-a7c3-4ddf-88b1-629b708b9cb90",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
@@ -15,7 +15,7 @@
     },
     {
       "slug": "hamming",
-      "uuid": "a93dbf6e-c65d-4793-9407-f8187abd0ad7",
+      "uuid": "a93dbf6e-c65d-4793-9407-f8187abd0ad",
       "core": false,
       "unlocked_by": null,
       "difficulty": 2,
@@ -26,7 +26,7 @@
     },
     {
       "slug": "sieve",
-      "uuid": "bc986de4-f76f-4435-b7aa-08e561693c49",
+      "uuid": "bc986de4-f76f-4435-b7aa-08e561693c4g",
       "core": false,
       "unlocked_by": null,
       "difficulty": 3,


### PR DESCRIPTION
Want to prevent any invalid UUIDs from being entered.

Want to put this in configlet lint, but can't:
exercism/configlet#99
exercism/configlet#168
So it will go in individual tracks' .travis.yml for now.

It appears that the site will accept pretty much arbitrary strings as
UUIDs for now, but we want to make less work for ourselves when valid
UUIDs are required.