### PR TITLE
remove most references to problem-specifications versions

### DIFF
--- a/exercises/anagram/source/anagram/AnagramTest.ceylon
+++ b/exercises/anagram/source/anagram/AnagramTest.ceylon
@@ -2,8 +2,6 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 1.5.0
-
 {[String, {String*}, {String*}]*} cases => {
     // no matches
     ["diaper", { "hello", "world", "zombies", "pants" }, {}],

--- a/exercises/hamming/source/hamming/HammingTest.ceylon
+++ b/exercises/hamming/source/hamming/HammingTest.ceylon
@@ -2,8 +2,6 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 2.3.0
-
 {[String, String, Integer?]*} cases => {
     // empty strands
     ["", "", 0],

--- a/exercises/largest-series-product/source/largestseriesproduct/SeriesTest.ceylon
+++ b/exercises/largest-series-product/source/largestseriesproduct/SeriesTest.ceylon
@@ -2,8 +2,6 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 1.2.0
-
 {[String, Integer, Integer|Error]*} cases => {
     // finds the largest product if span equals length
     ["29", 2, 18],

--- a/exercises/leap/source/leap/LeapTest.ceylon
+++ b/exercises/leap/source/leap/LeapTest.ceylon
@@ -2,8 +2,6 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 1.5.1
-
 {[Integer, Boolean]*} cases => {
     [2015, false],
     [1970, false],

--- a/exercises/matching-brackets/source/matchingbrackets/BracketsTest.ceylon
+++ b/exercises/matching-brackets/source/matchingbrackets/BracketsTest.ceylon
@@ -2,8 +2,6 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 2.0.0
-
 {[String, Boolean]*} cases => {
     // paired square brackets
     ["[]", true],

--- a/exercises/react/source/react/ReactorTest.ceylon
+++ b/exercises/react/source/react/ReactorTest.ceylon
@@ -2,8 +2,6 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 2.0.0
-
 test
 void inputCellsHaveValue() {
     value r = Reactor<Integer>();

--- a/exercises/rna-transcription/source/rnatranscription/RNATest.ceylon
+++ b/exercises/rna-transcription/source/rnatranscription/RNATest.ceylon
@@ -2,9 +2,6 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 1.3.0
-// The Ceylon track keeps the Error cases from 1.0.1 (removed in 1.1.0)
-
 {[String, String|Null]*} cases => {
     // empty strand
     ["", ""],
@@ -18,6 +15,8 @@ import ceylon.test {
     ["T", "A"],
     // longer strand
     ["ACGTGGTCTTAA", "UGCACCAGAAUU"],
+    // The Ceylon track keeps these Error cases,
+    // from problem-specifications 1.0.1 (removed in 1.1.0)
     // strand with DNA nucleotides
     ["U", null],
     // strand with invalid nucleotides

--- a/exercises/sieve/source/sieve/SieveTest.ceylon
+++ b/exercises/sieve/source/sieve/SieveTest.ceylon
@@ -2,8 +2,6 @@ import ceylon.test {
     ...
 }
 
-// Tests adapted from problem-specifications version 1.1.0
-
 {Integer*} cases => { 1, 2, 10, 13, 1000 };
 
 [Integer+] primes1000 = [


### PR DESCRIPTION
since we're in the new world of .meta/tests.toml now.
However, I had to leave in the reference where the Ceylon track keeps
some tests that are no longer in the canonical data.