### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Ceylon is a general-purpose programming language featuring a syntax similar to Java and C#.
 It is imperative, statically-typed, block-structured, object-oriented, and higher-order.
 By _statically-typed_, we mean that the compiler performs extensive type checking, with

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 The easiest way to install Ceylon is simply to **not** install it.
 You should be able to solve most of the exercises using our [web IDE](http://try.ceylon-lang.org/).
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 The best way to get started with Ceylon right now is to read the [quick introduction](http://ceylon-lang.org/documentation/1.3/introduction/),
 then [take the tour](http://ceylon-lang.org/documentation/1.3/tour/) and/or [the walkthrough](http://ceylon-lang.org/documentation/1.3/walkthrough/).
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 * [Language specification](https://www.ceylon-lang.org/documentation/1.3/spec/)
 * [Reference](https://www.ceylon-lang.org/documentation/1.3/reference/)
 * [API documentation for the `language` module](https://modules.ceylon-lang.org/repo/1/ceylon/language/1.3.3/module-doc/api/index.html)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## Running Ceylon Tests
+# Running Ceylon Tests
 
 Before tests can be run, your code must be compiled via [`ceylon compile`](https://ceylon-lang.org/documentation/current/reference/tool/ceylon/subcommands/ceylon-compile.html).
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
