### PR TITLE
maintainers: my resignation as a Ceylon track maintainer

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -13,13 +13,13 @@
     },
     {
       "github_username": "petertseng",
-      "alumnus": false,
+      "alumnus": true,
       "show_on_website": true,
       "name": null,
       "link_text": null,
       "link_url": null,
       "avatar_url": null,
-      "bio": "I was introduced to Ceylon by a contributor to the project. I found the union and intersection types interesting and thus I took the track under my wing. I find the track a good way to test Ceylon code and ideas. Getting the track officially launched isn't the highest on my priority list, but I'm happy to advise an interested party in making it happen."
+      "bio": "I was introduced to Ceylon by a contributor to the project. I found the union and intersection types interesting and thus I took the track under my wing. I find the track a good way to test Ceylon code and ideas. Eventually I moved on from the language, but I will continue to watch with interest if any future Ceylon releases happen, and wish this track the best of luck!"
     }
   ]
 }


### PR DESCRIPTION
This resignation is effective for the Ceylon track only. Other tracks
will be evaluated on a case-by-case basis.

The primary reason is that I've moved on from the language.
I haven't even had it installed for the past few years and have pretty
much solely relied on CI to see whether things still compile.

The secondary reason is it's too lonely being a sole maintainer.
(But even if another maintainer for this language were to become active,
the primary reason would still remain, so that will not cause me to
reconsider this resignation)

The track was a useful way to test tooling since it was a small track
with few exercises, but I think that if the need arises to test tooling
then I would be better served finding a different small track to use.