### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "29e23a84-d056-488a-90d0-e966ced8eb5d",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Ceylon locally",
+      "blurb": "Learn how to install Ceylon locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "20b4a579-c926-4082-a7b2-a1532b7844bc",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Ceylon",
+      "blurb": "An overview of how to get started from scratch with Ceylon"
+    },
+    {
+      "uuid": "a9f257c7-d05d-4975-a2eb-974f3144ab78",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Ceylon track",
+      "blurb": "Learn how to test your Ceylon exercises on Exercism"
+    },
+    {
+      "uuid": "ba686b52-088b-439c-a458-96c6fb48c6b6",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Ceylon resources",
+      "blurb": "A collection of useful resources to help you master Ceylon"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
