### PR TITLE
README: Link the Tests badge to the workflow results page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exercism Ceylon Track
 
-![Tests](https://github.com/exercism/ceylon/workflows/Tests/badge.svg)
+[![Tests](https://github.com/exercism/ceylon/workflows/Tests/badge.svg)](https://github.com/exercism/ceylon/actions/workflows/tests.yml)
 
 Exercism problems in Ceylon.
 


### PR DESCRIPTION
Currently clicking the badge just links you to the image, which is much
less useful than linking to the tests results page. You could even add
`?query=branch%3Amain` but before doing that the workflow would have to
be

1. fixed
2. reconfigured to run on main not master.


Reminder: I no longer hold maintainer interest in this track anymore so a maintainer (not me) will have to merge it. Please don't misinterpret this PR as indication that I've regained maintainer interest - the reasons for my resignation in https://github.com/exercism/ceylon/pull/117 still apply.